### PR TITLE
Fix: use libtinfo6 instead of libtinfo5

### DIFF
--- a/.github/renovate-entrypoint.sh
+++ b/.github/renovate-entrypoint.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 sudo apt-get install --assume-yes --no-install-recommends \
-        libtinfo5 \
+        libtinfo6 \
         git 
 sudo mkdir apax-dep
 sudo npm config set prefix "~/.local/"

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .apax/
 bin/
 obj/
+/.vs

--- a/setup-apax-runner/action.yml
+++ b/setup-apax-runner/action.yml
@@ -24,7 +24,7 @@ runs:
         SCRIPT_PATH: actions
       run: |
         sudo apt-get install --assume-yes --no-install-recommends \
-        libtinfo5 \
+        libtinfo6 \
         git 
         npm -v
         node -v


### PR DESCRIPTION
In the new Ubuntu verion is libtinfo5 changed for libtinfo6  - so fix use.

And i add my gitignor for vs.