### PR TITLE
chore: Adds a conventional commit compliance workflow

### DIFF
--- a/.github/workflows/check-conventional-commit-compliance.yml
+++ b/.github/workflows/check-conventional-commit-compliance.yml
@@ -1,0 +1,33 @@
+
+name: PR Title Conventional Commit Check
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  check-pr-title:
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Check PR title for Conventional Commits compliance
+        uses: amannn/action-semantic-pull-request@v5
+        with:
+          types: |
+            feat
+            fix
+            docs
+            style
+            refactor
+            perf
+            test
+            build
+            ci
+            chore
+          requireScope: false
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Adds a new GitHub Actions workflow to enforce Conventional Commits on PR titles.